### PR TITLE
Fix: L trigger is backwards (press = unpress)

### DIFF
--- a/src/pc/controller/controller_sdl.c
+++ b/src/pc/controller/controller_sdl.c
@@ -219,7 +219,7 @@ static void controller_sdl_read(OSContPad *pad) {
         update_button(i, new);
     }
 
-    update_button(VK_LTRIGGER - VK_BASE_SDL_GAMEPAD, ltrig > AXIS_THRESHOLD);
+    update_button(VK_LTRIGGER - VK_BASE_SDL_GAMEPAD, ltrig < AXIS_THRESHOLD);
     update_button(VK_RTRIGGER - VK_BASE_SDL_GAMEPAD, rtrig > AXIS_THRESHOLD);
 
     u32 buttons_down = 0;


### PR DESCRIPTION
This fixes the issue on my Xbox Controller S (DirectInput), I don't have any other controllers so I can't test it.

(trying again)