### PR TITLE
Revert "Fix: L trigger is backwards (press = unpress)"

### DIFF
--- a/src/pc/controller/controller_sdl.c
+++ b/src/pc/controller/controller_sdl.c
@@ -219,7 +219,7 @@ static void controller_sdl_read(OSContPad *pad) {
         update_button(i, new);
     }
 
-    update_button(VK_LTRIGGER - VK_BASE_SDL_GAMEPAD, ltrig < AXIS_THRESHOLD);
+    update_button(VK_LTRIGGER - VK_BASE_SDL_GAMEPAD, ltrig > AXIS_THRESHOLD);
     update_button(VK_RTRIGGER - VK_BASE_SDL_GAMEPAD, rtrig > AXIS_THRESHOLD);
 
     u32 buttons_down = 0;


### PR DESCRIPTION
Reverts Render96/Render96ex#2

Can't confirm 100% as I don't have an Xbox One S specific controller, however:
0) both my (wired) Xbox 360* & (wired) Xbox One controller get reversed with this commit
1) **every** other fork that doesn't have this change hasn't elicited complaints

*confirm by DorfDork