### PR TITLE
text-loader refactoring, needed to make DynOS 0.7 compatible

### DIFF
--- a/src/game/options_menu.c
+++ b/src/game/options_menu.c
@@ -507,7 +507,7 @@ static void optmenu_opt_change(struct Option *opt, s32 val) {
             break;
 
         case OPT_CHOICE:
-            *opt->uval = wrap_add(*opt->uval, val, 0, strcmp(opt->label, optsGameStr[0]) == 0 ? languagesAmount - 1: opt->numChoices - 1);
+            *opt->uval = wrap_add(*opt->uval, val, 0, strcmp(opt->label, optsGameStr[0]) == 0 ? get_num_languages() - 1: opt->numChoices - 1);
             set_language(languages[configLanguage]);
             break;
 

--- a/src/pc/dynamic_options.c
+++ b/src/pc/dynamic_options.c
@@ -968,7 +968,7 @@ static const unsigned char *r96lang(struct DynosOption *opt) {
     unsigned char *s = getTranslatedText(languages[*opt->choice.pindex]->name);
     memcpy(buffer, s, str64l(s) + 1);
     free(s);
-    opt->choice.count = languagesAmount;
+    opt->choice.count = get_num_languages();
     return str64d(buffer);
 }
 

--- a/src/text/text-loader.h
+++ b/src/text/text-loader.h
@@ -5,7 +5,6 @@
 #include "game/ingame_menu.h"
 
 extern char* currentLanguage;
-extern u8 languagesAmount;
 
 extern struct DialogEntry* * dialogPool;
 extern u8* * seg2_course_name_table;
@@ -25,12 +24,17 @@ struct LanguageEntry {
     int num_strings;
     u8* * courses;
     u8* * acts;
+    u8* none;
 };
 
-extern u8* get_key_string(char* id);
+extern u8* get_key_string(const char* id);
+extern void add_key_value_string(struct LanguageEntry *lang, const char *key, const char *value);
 extern struct LanguageEntry* get_language_by_name(char* name);
 extern struct LanguageEntry* get_language();
 extern void set_language(struct LanguageEntry* new_language);
-extern void alloc_dialog_pool(char* exePath, char* gamedir);
+extern void load_language_file(const char *filename);
+extern void alloc_dialog_pool(char *exePath, char *gamedir);
 extern void dealloc_dialog_pool(void);
+extern int get_num_languages();
+
 #endif


### PR DESCRIPTION
Works the same as before, but now can load a language from multiple files (CHEATER can now have its separate JSON files, instead of modifying the original language files).
Fixed some memory leaks and added the "NONE" string (when a string id has no value) as a member or the LanguageEntry struct.

**void load_language_file(const char \*filename)**
Load a JSON file from anywhere in the code. The filename must be the absolute or relative path (from the exe) to the JSON file.
Note that every JSON file present in the "build/us_pc/res/texts" folder is automatically loaded when launching the game.

**void add_key_value_string(struct LanguageEntry \*lang, const char \*key, const char \*value)**
Add a key/value string from anywhere in the code, for a specified language.

**int get_num_languages()**
Return the number of loaded languages. This value can change if a new language is loaded during runtime.