### PR TITLE
Fix previous implicit declaration

### DIFF
--- a/data/r96/system/r96_audio.c
+++ b/data/r96/system/r96_audio.c
@@ -156,6 +156,13 @@ void r96_play_cap_music(const char* R96_CAP_MUSIC) {
     }
 }
 
+void r96_music_fade_out() {
+    softenVolume -= 0.10f;
+    if (softenVolume <= 0.20f) {
+        softenVolume = 0.20f;
+    }
+}
+
 void r96_fadeout_cap_music() {
     if (sR96CurrentCapMusic != NO_MUSIC) {
         r96_music_fade_out();
@@ -253,13 +260,6 @@ void r96_music_fade_in() {
     }
     if (softenVolume >= 1.0f) {
         softenVolume = 1.0f;
-    }
-}
-
-void r96_music_fade_out() {
-    softenVolume -= 0.10f;
-    if (softenVolume <= 0.20f) {
-        softenVolume = 0.20f;
     }
 }
 

--- a/data/r96/system/r96_wario_moves.c
+++ b/data/r96/system/r96_wario_moves.c
@@ -95,6 +95,27 @@ s32 act_wario_pile_driver(struct MarioState *m) {
     return FALSE;
 }
 
+/*Coin Magnet thanks 4y*/
+void coin_magnet_wario(struct MarioState *m) {
+        struct Object* coinMagMove = cur_obj_nearest_object_with_behavior(bhvMovingYellowCoinWario);
+        f32 oDistMove;
+        if (coinMagMove != NULL && m->marioObj != NULL) {
+            oDistMove = dist_between_objects(coinMagMove, m->marioObj);
+        }
+        while (coinMagMove != NULL && oDistMove >= 100 && oDistMove < 1000) {
+            while (oDistMove >= 10) {
+                coinMagMove->oPosX = approach_f32_symmetric(coinMagMove->oPosX, m->pos[0], 28);
+                coinMagMove->oPosY = approach_f32_symmetric(coinMagMove->oPosY, m->pos[1], 28);
+                coinMagMove->oPosZ = approach_f32_symmetric(coinMagMove->oPosZ, m->pos[2], 28);
+                break;
+            }
+            break;
+        }
+        if (oDistMove == 0 && oDistMove > 1000) {
+            obj_mark_for_deletion(coinMagMove);
+        }
+}
+
 s32 act_wario_pile_driver_land(struct MarioState *m) {
     m->actionState = 1;
     queue_rumble_data(4, 50);
@@ -213,27 +234,6 @@ s32 act_wario_triple_jump(struct MarioState *m) {
         set_mario_animation(m, MARIO_ANIM_GENERAL_FALL);
     }
     return FALSE;
-}
-
-/*Coin Magnet thanks 4y*/
-void coin_magnet_wario(struct MarioState *m) {
-        struct Object* coinMagMove = cur_obj_nearest_object_with_behavior(bhvMovingYellowCoinWario);
-        f32 oDistMove;
-        if (coinMagMove != NULL && m->marioObj != NULL) {
-            oDistMove = dist_between_objects(coinMagMove, m->marioObj);
-        }
-        while (coinMagMove != NULL && oDistMove >= 100 && oDistMove < 1000) {
-            while (oDistMove >= 10) {
-                coinMagMove->oPosX = approach_f32_symmetric(coinMagMove->oPosX, m->pos[0], 28);
-                coinMagMove->oPosY = approach_f32_symmetric(coinMagMove->oPosY, m->pos[1], 28);
-                coinMagMove->oPosZ = approach_f32_symmetric(coinMagMove->oPosZ, m->pos[2], 28);
-                break;
-            }
-            break;
-        }
-        if (oDistMove == 0 && oDistMove > 1000) {
-            obj_mark_for_deletion(coinMagMove);
-        }
 }
 
 void update_wario_spin_walk_speed(struct MarioState *m) {

--- a/src/game/behaviors/got_milk.inc.c
+++ b/src/game/behaviors/got_milk.inc.c
@@ -64,6 +64,15 @@ void bhv_milk_loop(void)
     set_object_visibility(o, 3000);
 }
 
+void bhv_milk_end(void) {
+    vec3f_set(gMarioState->marioObj->header.gfx.scale, 1.0f, 1.0f, 1.0f);
+    s = 0;
+    gMarioState->milk = 0;
+    gMarioState->defeatEnemy = 0;
+    o->activeFlags = ACTIVE_FLAG_DEACTIVATED;
+    r96_stop_music();
+}
+
 void bhv_milk_time_out(void)
 {
     u16 timerValFrames;
@@ -82,11 +91,3 @@ void bhv_milk_time_out(void)
     }
 }
 
-void bhv_milk_end() {
-    vec3f_set(gMarioState->marioObj->header.gfx.scale, 1.0f, 1.0f, 1.0f);
-    s = 0;
-    gMarioState->milk = 0;
-    gMarioState->defeatEnemy = 0;
-    o->activeFlags = ACTIVE_FLAG_DEACTIVATED;
-    r96_stop_music();
-}


### PR DESCRIPTION
I run into some errors while trying to compile on Linux Mint 20:

```make
src/game/behaviors/got_milk.inc.c:85:6: error: conflicting types for 'bhv_milk_end'
void bhv_milk_end() {
     ^
src/game/behaviors/got_milk.inc.c:77:9: note: previous implicit declaration is here
        bhv_milk_end();
```

And 2 similar errors on other files.

I fixed them by moving the functions before they were called so there are no implicit declarations, and I now manage to compile without errors. I'm not sure why I'm getting these errors while others don't (as I doubt I am the first one to compile that on Linux), but in case someone else might run into the same problem, I figured I might as well do a pull request.