### PR TITLE
macOS fixes

### DIFF
--- a/data/dynos.h
+++ b/data/dynos.h
@@ -10,7 +10,11 @@
 #include <math.h>
 #include <limits.h>
 #include <dirent.h>
+#ifdef OSX_BUILD
+#include <SDL.h>
+#else
 #include <SDL2/SDL.h>
+#endif
 #ifdef __cplusplus
 #include <new>
 #include <utility>

--- a/data/dynos_audio.cpp
+++ b/data/dynos_audio.cpp
@@ -1,7 +1,17 @@
 #include "dynos.cpp.h"
+#ifdef OSX_BUILD
+#include <SDL.h>
+#else
 #include <SDL2/SDL.h>
+#endif
 extern "C" {
 #include "game/area.h"
+
+#ifdef OSX_BUILD
+// disable CoreAudio on macOS
+#define MA_NO_COREAUDIO
+#endif
+
 #include "r96/r96_miniaudio.h"
 #include "r96/system/r96_system.h"
 }

--- a/src/pc/audio/audio_sdl.c
+++ b/src/pc/audio/audio_sdl.c
@@ -1,6 +1,10 @@
 #ifdef AAPI_SDL2
 
+#ifdef OSX_BUILD
+#include <SDL.h>
+#else
 #include <SDL2/SDL.h>
+#endif
 
 #include "audio_api.h"
 

--- a/src/pc/controller/controller_sdl.c
+++ b/src/pc/controller/controller_sdl.c
@@ -5,9 +5,13 @@
 #include <stdbool.h>
 #include <math.h>
 
+#ifdef OSX_BUILD
+#include <SDL.h>
+#else
 #include <SDL2/SDL.h>
+#endif
 
-// Analog camera movement by Pathétique (github.com/vrmiguel), y0shin and Mors
+// Analog camera movement by Path??tique (github.com/vrmiguel), y0shin and Mors
 // Contribute or communicate bugs at github.com/vrmiguel/sm64-analog-camera
 
 #include <ultra64.h>

--- a/src/pc/gfx/gfx_opengl.c
+++ b/src/pc/gfx/gfx_opengl.c
@@ -21,13 +21,25 @@
     #endif
 #endif
 
+#ifdef OSX_BUILD
+#include <SDL.h>
+#else
 #include <SDL2/SDL.h>
+#endif
 
 #define GL_GLEXT_PROTOTYPES 1
 #ifdef USE_GLES
+# ifdef OSX_BUILD
+# include <SDL_opengles2.h>
+# else
 # include <SDL2/SDL_opengles2.h>
+# endif
 #else
+# ifdef OSX_BUILD
+# include <SDL_opengl.h>
+# else
 # include <SDL2/SDL_opengl.h>
+# endif
 #endif
 
 #include "../platform.h"

--- a/src/pc/gfx/gfx_sdl2.c
+++ b/src/pc/gfx/gfx_sdl2.c
@@ -13,11 +13,15 @@
 #define GL_GLEXT_PROTOTYPES 1
 #include <SDL2/SDL_opengl.h>
 #else
+#ifdef OSX_BUILD
+#include <SDL.h>
+#else
 #include <SDL2/SDL.h>
+#endif
 #define GL_GLEXT_PROTOTYPES 1
 
 #ifdef OSX_BUILD
-#include <SDL2/SDL_opengl.h>
+#include <SDL_opengl.h>
 #else
 #include <SDL2/SDL_opengles2.h>
 #endif

--- a/src/pc/platform.c
+++ b/src/pc/platform.c
@@ -83,7 +83,11 @@ void sys_fatal(const char *fmt, ...) {
 #ifdef HAVE_SDL2
 
 // we can just ask SDL for most of this shit if we have it
+#ifdef OSX_BUILD
+#include <SDL.h>
+#else
 #include <SDL2/SDL.h>
+#endif
 
 // TEMPORARY: check the old save folder and copy contents to the new path
 // this will be removed after a while


### PR DESCRIPTION
Here are the fixes required to allow compilation on macOS.  Tested on an Apple MacBook M1 Pro running macOS Ventura v13.2.1 with GCC v12.2.0 (via Homebrew).

This also requires SDL2.framework to be installed (https://github.com/libsdl-org/SDL/releases) from the latest DMG file.

(NOTE:  This probably only works for Homebrew and not MacPorts)