### PR TITLE
Update Dockerfile to Ubuntu 22.04 as 18.04 is EOL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,16 @@
-FROM ubuntu:18.04 as build
+FROM ubuntu:22.04 as build
 
 RUN apt-get update && \
     apt-get install -y \
-        binutils-mips-linux-gnu \
-        bsdmainutils \
         build-essential \
-        libaudiofile-dev \
-        python3 \
-        wget
+        git \
+        libglew-dev \
+        libsdl2-dev \
+        python3
 
-RUN wget \
-        https://github.com/n64decomp/qemu-irix/releases/download/v2.11-deb/qemu-irix-2.11.0-2169-g32ab296eef_amd64.deb \
-        -O qemu.deb && \
-    echo 8170f37cf03a08cc2d7c1c58f10d650ea0d158f711f6916da9364f6d8c85f741 qemu.deb | sha256sum --check && \
-    dpkg -i qemu.deb && \
-    rm qemu.deb
+RUN mkdir /render96ex
+WORKDIR /render96ex
+ENV PATH="/render96ex/tools:${PATH}"
 
-RUN mkdir /sm64
-WORKDIR /sm64
-ENV PATH="/sm64/tools:${PATH}"
-
-CMD echo 'usage: docker run --rm --mount type=bind,source="$(pwd)",destination=/sm64 sm64 make VERSION=${VERSION:-us} -j4\n' \
-         'see https://github.com/n64decomp/sm64/blob/master/README.md for advanced usage'
+CMD echo 'Usage: docker run --rm -v ${PWD}:/render96ex render96ex make VERSION=${VERSION:-us} -j4\n' \
+         'See https://github.com/Render96/Render96ex/blob/master/README.md for more information'


### PR DESCRIPTION
also:

- fix some things that probably broke building before because it was made for the original decomp

Related pull for sm64ex: https://github.com/sm64pc/sm64ex/pull/538

Related pull for original decomp: https://github.com/n64decomp/sm64/pull/91