### PR TITLE
Fix compilation with GCC 14 on macOS (alpha Branch)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,8 +102,17 @@ endif
 # macOS overrides
 ifeq ($(HOST_OS),Darwin)
   OSX_BUILD := 1
+  # Using Homebrew?
+  ifeq ($(shell which brew >/dev/null 2>&1 && echo y),y)
+    PLATFORM := $(shell uname -m)
+    OSX_GCC_VER = $(shell find `brew --prefix`/bin/gcc* | grep -oE '[[:digit:]]+' | sort -n | uniq | tail -1)
+    CC := gcc-$(OSX_GCC_VER)
+    CXX := g++-$(OSX_GCC_VER)
+    CPP := cpp-$(OSX_GCC_VER) -P
+    PLATFORM_CFLAGS := -I $(shell brew --prefix)/include
+    PLATFORM_LDFLAGS := -L $(shell brew --prefix)/lib
   # Using MacPorts?
-  ifeq ($(shell test -d /opt/local/lib && echo y),y)
+  else ifeq ($(shell test -d /opt/local/lib && echo y),y)
     OSX_GCC_VER = $(shell find /opt/local/bin/gcc* | grep -oE '[[:digit:]]+' | sort -n | uniq | tail -1)
     CC := gcc-mp-$(OSX_GCC_VER)
     CXX := g++-mp-$(OSX_GCC_VER)
@@ -111,42 +120,7 @@ ifeq ($(HOST_OS),Darwin)
     PLATFORM_CFLAGS := -I /opt/local/include
     PLATFORM_LDFLAGS := -L /opt/local/lib
   else
-    # Using Homebrew?
-    ifeq ($(shell which brew >/dev/null 2>&1 && echo y),y)
-      OSX_GCC_VER = $(shell find `brew --prefix`/bin/gcc* | grep -oE '[[:digit:]]+' | sort -n | uniq | tail -1)
-      CC := gcc-$(OSX_GCC_VER)
-      CXX := g++-$(OSX_GCC_VER)
-      CPP := cpp-$(OSX_GCC_VER) -P
-      PLATFORM_CFLAGS := -I /usr/local/include
-      PLATFORM_LDFLAGS := -L /usr/local/lib
-    else
-      $(error No suitable macOS toolchain found, have you installed Homebrew?)
-    endif
-  endif
-endif
-
-# macOS overrides
-ifeq ($(HOST_OS),Darwin)
-  OSX_BUILD := 1
-  # Using Homebrew?
-  ifeq ($(shell which brew >/dev/null 2>&1 && echo y),y)
-	PLATFORM := $(shell uname -m)
-	OSX_GCC_VER = $(shell find `brew --prefix`/bin/gcc* | grep -oE '[[:digit:]]+' | sort -n | uniq | tail -1)
-	CC := gcc-$(OSX_GCC_VER)
-	CXX := g++-$(OSX_GCC_VER)
-	CPP := cpp-$(OSX_GCC_VER) -P
-	PLATFORM_CFLAGS := -I $(shell brew --prefix)/include
-	PLATFORM_LDFLAGS := -L $(shell brew --prefix)/lib
-  # Using MacPorts?
-  else ifeq ($(shell test -d /opt/local/lib && echo y),y)
-	OSX_GCC_VER = $(shell find /opt/local/bin/gcc* | grep -oE '[[:digit:]]+' | sort -n | uniq | tail -1)
-	CC := gcc-mp-$(OSX_GCC_VER)
-	CXX := g++-mp-$(OSX_GCC_VER)
-	CPP := cpp-mp-$(OSX_GCC_VER) -P
-	PLATFORM_CFLAGS := -I /opt/local/include
-	PLATFORM_LDFLAGS := -L /opt/local/lib
-  else
-	$(error No suitable macOS toolchain found, have you installed Homebrew?)
+    $(error No suitable macOS toolchain found, have you installed Homebrew?)
   endif
 endif
 

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,6 +1,6 @@
 CC ?= gcc
 CXX ?= g++
-CFLAGS := -I../include -I. -Wall -Wextra -Wno-unused-parameter -pedantic -std=c99 -O2 -s
+CFLAGS := -I../include -I. -Wall -Wextra -Wno-unused-parameter -pedantic -std=c99 -O2 -s -fpermissive
 LDFLAGS := -lm
 PROGRAMS := n64graphics aifc_decode aiff_extract_codebook mio0 vadpcm_enc tabledesign skyconv
 


### PR DESCRIPTION
Hi, I've recently tried to build the latest version of the game on macOS and it has failed for two reasons:

1. Whoever merged the new macOS overrides accidentally duplicated the overrides with both the old and new versions.
2. Tools also need the `-fpermissive` flag to build (at least on macOS).