### PR TITLE
Rework ending cutscene timings

### DIFF
--- a/src/game/camera.c
+++ b/src/game/camera.c
@@ -7392,12 +7392,12 @@ BAD_RETURN(s32) cutscene_ending_peach_wakeup(struct Camera *c) {
     cutscene_event(cutscene_ending_look_up_at_castle, c, 0, 0);
 #ifdef VERSION_EU
     cutscene_event(cutscene_ending_look_up_at_castle, c, 265, -1);
-    cutscene_spawn_obj(7, 315);
-    cutscene_spawn_obj(9, 355);
+    cutscene_spawn_obj(7, 320);
+    cutscene_spawn_obj(9, 360);
 #else
     cutscene_event(cutscene_ending_look_up_at_castle, c, 250, -1);
-    cutscene_spawn_obj(7, 300);
-    cutscene_spawn_obj(9, 340);
+    cutscene_spawn_obj(7, 305);
+    cutscene_spawn_obj(9, 345);
 #endif
     vec3f_set(c->pos, -163.f, 978.f, -1082.f);
     player2_rotate_cam(c, -0x800, 0x2000, -0x2000, 0x2000);
@@ -7445,7 +7445,7 @@ BAD_RETURN(s32) cutscene_ending_kiss(struct Camera *c) {
 #ifdef VERSION_EU
     cutscene_event(cutscene_ending_kiss_here_we_go, c, 185, -1);
 #else
-    cutscene_event(cutscene_ending_kiss_here_we_go, c, 155, -1);
+    cutscene_event(cutscene_ending_kiss_here_we_go, c, 161, -1);
 #endif
     player2_rotate_cam(c, -0x800, 0x2000, -0x2000, 0x2000);
 }
@@ -7472,12 +7472,12 @@ BAD_RETURN(s32) cutscene_ending_zoom_fov(UNUSED struct Camera *c) {
 BAD_RETURN(s32) cutscene_ending_cake_for_mario(struct Camera *c) {
     cutscene_event(cutscene_ending_reset_spline, c, 0, 0);
     cutscene_event(cutscene_ending_look_at_sky, c, 0, 0);
-    cutscene_event(cutscene_ending_zoom_fov, c, 0, 499);
-    cutscene_event(cutscene_ending_look_at_sky, c, 500, -1);
-    cutscene_spawn_obj(8, 600);
-    cutscene_spawn_obj(8, 608);
-    cutscene_spawn_obj(8, 624);
-    cutscene_spawn_obj(8, 710);
+    cutscene_event(cutscene_ending_zoom_fov, c, 0, 518);
+    cutscene_event(cutscene_ending_look_at_sky, c, 519, -1);
+    cutscene_spawn_obj(8, 619);
+    cutscene_spawn_obj(8, 627);
+    cutscene_spawn_obj(8, 643);
+    cutscene_spawn_obj(8, 729);
 }
 
 /**
@@ -10386,13 +10386,13 @@ struct Cutscene sCutsceneEnding[] = {
     { cutscene_ending_kiss, 0x10b },
 #else
     { cutscene_ending_mario_land_closeup, 75 },
-    { cutscene_ending_stars_free_peach, 386 },
-    { cutscene_ending_peach_appears, 139 },
-    { cutscene_ending_peach_descends, 590 },
-    { cutscene_ending_mario_to_peach, 95 },
-    { cutscene_ending_peach_wakeup, 425 },
-    { cutscene_ending_dialog, 236 },
-    { cutscene_ending_kiss, 245 },
+    { cutscene_ending_stars_free_peach, 394 },
+    { cutscene_ending_peach_appears, 149 },
+    { cutscene_ending_peach_descends, 615 },
+    { cutscene_ending_mario_to_peach, 91 },
+    { cutscene_ending_peach_wakeup, 454 },
+    { cutscene_ending_dialog, 252 },
+    { cutscene_ending_kiss, 259 },
 #endif
     { cutscene_ending_cake_for_mario, CUTSCENE_LOOP },
     { cutscene_ending_stop, 0 }

--- a/src/game/mario_actions_cutscene.c
+++ b/src/game/mario_actions_cutscene.c
@@ -2054,7 +2054,7 @@ static void end_peach_cutscene_summon_jumbo_star(struct MarioState *m) {
     if (m->actionState == 0 && is_anim_past_end(m)) {
         m->actionState++;
     }
-    if (m->actionTimer == 90) {
+    if (m->actionTimer == 85) {
         r96_play_jingle(R96_EVENT_PEACH_ENDING);
     }
     if (m->actionTimer == 255) {
@@ -2066,8 +2066,8 @@ static void end_peach_cutscene_summon_jumbo_star(struct MarioState *m) {
     play_sound(SOUND_AIR_PEACH_TWINKLE, sEndJumboStarObj->header.gfx.cameraToObject);
 }
 
-#define TIMER_FADE_IN_PEACH 276
-#define TIMER_DESCEND_PEACH 355
+#define TIMER_FADE_IN_PEACH 284
+#define TIMER_DESCEND_PEACH 373
 
 // free peach from the stained glass window
 static void end_peach_cutscene_spawn_peach(struct MarioState *m) {
@@ -2120,7 +2120,7 @@ static void end_peach_cutscene_spawn_peach(struct MarioState *m) {
     }
 }
 
-#define TIMER_RUN_TO_PEACH 584
+#define TIMER_RUN_TO_PEACH 609
 
 // descend peach
 static void end_peach_cutscene_descend_peach(struct MarioState *m) {
@@ -2223,14 +2223,14 @@ static void end_peach_cutscene_dialog_1(struct MarioState *m) {
             r96_play_character_sound(m, R96_MARIO_PEACH_POWER_OF_THE_STARS, R96_LUIGI_PEACH_POWER_OF_THE_STARS, R96_WARIO_PEACH_POWER_OF_THE_STARS);
             break;
 
-        case 480:
+        case 504:
             advance_cutscene_step(m);
             break;
     }
 }
 
-#define TIMER_SOMETHING_SPECIAL 130
-#define TIMER_PEACH_KISS        200
+#define TIMER_SOMETHING_SPECIAL 136
+#define TIMER_PEACH_KISS        220
 
 // dialog 2
 // "...and it's all thanks to you!"
@@ -2249,7 +2249,7 @@ static void end_peach_cutscene_dialog_2(struct MarioState *m) {
             D_8032CBE8 = 1;
             break;
 
-        case 75:
+        case 78:
             set_cutscene_message(160, 227, 3, 30);
             r96_play_character_sound(m, R96_MARIO_PEACH_THANK_YOU_MARIO, R96_LUIGI_PEACH_THANK_YOU_LUIGI, R96_WARIO_PEACH_THANK_YOU_WARIO);
             break;
@@ -2286,35 +2286,35 @@ static void end_peach_cutscene_kiss_from_peach(struct MarioState *m) {
     }
 
     switch (m->actionTimer) {
-        case 8:
+        case 14:
             D_8032CBE8 = 0;
             break;
 
-        case 10:
+        case 16:
             D_8032CBE4 = 3;
             break;
 
-        case 50:
+        case 56:
             D_8032CBE4 = 4;
             break;
 
-        case 75:
+        case 81:
             m->marioBodyState->eyeState = MARIO_EYES_HALF_CLOSED;
             break;
 
-        case 76:
+        case 82:
             m->marioBodyState->eyeState = MARIO_EYES_CLOSED;
             break;
 
-        case 100:
+        case 106:
             D_8032CBE4 = 3;
             break;
 
-        case 136:
+        case 142:
             D_8032CBE4 = 0;
             break;
 
-        case 140:
+        case 146:
             advance_cutscene_step(m);
             break;
     }
@@ -2354,12 +2354,16 @@ static void end_peach_cutscene_star_dance(struct MarioState *m) {
             D_8032CBE4 = 0;
             break;
 
-        case 140:
+        case 125:
+            r96_jingle_fade_out();
+            break;
+
+        case 145:
             sequence_player_unlower(SEQ_PLAYER_LEVEL, 60);
             r96_play_jingle(R96_EVENT_CREDITS);
             break;
 
-        case 142:
+        case 147:
             advance_cutscene_step(m);
             break;
     }
@@ -2396,7 +2400,7 @@ static void end_peach_cutscene_dialog_3(struct MarioState *m) {
             break;
     }
 
-    if (m->actionTimer == 350) {
+    if (m->actionTimer == 375) {
         advance_cutscene_step(m);
     }
 }


### PR DESCRIPTION
Fixes the ending desync that occurs due to engine rework to accomodate 30 and 60 FPS. Was never reported for some reason and outlooked in my #117 issue because that was off-topic.

The aim was to sync it as much as possible to the music, with N64 US version as a reference point. Tried to avoid as much akward long pauses since I didn't want to take risk editing the camera.

### **Alpha branch**

https://github.com/Render96/Render96ex/assets/133251163/779bba63-9352-4344-afc8-c020769d4179


### **This PR**

https://github.com/Render96/Render96ex/assets/133251163/b8c7c92d-681d-433e-aa59-1ccde6dd8ca1






